### PR TITLE
kanaries-track 0.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 0b154cd2acdd3dc96804fc05aea7579d043353917a5c74fee4d9028c79126f2c
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - dateutils >=0.6.12
     - requests >=2.31.0
     - backoff >=2.2.1
@@ -32,13 +31,17 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
+    - python
 
 about:
-  home: https://pypi.org/project/kanareis-track/
-  summary: 'kanaries_track: track to kanaries data infra'
+  home: https://pypi.org/project/kanaries-track/
+  summary: track to kanaries data infra
+  description: track to kanaries data infra
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  doc_url: https://pypi.org/project/kanaries-track/
+  dev_url: https://github.com/Kanaries/kanaries-track
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9856](https://anaconda.atlassian.net/browse/PKG-9856)
- [Upstream repository](https://github.com/Kanaries/kanaries-track)
- https://package-build.anaconda.com/v1/graph/92da54e2-64cc-4b65-b971-1498efbd7a13
- to satisfy https://github.com/Kanaries/pygwalker/blob/986d47e0f62178389a6a6b7e8d5b6fd712547825/pyproject.toml#L33
- Relevant dependency PRs:
  - [PKG-9838](https://anaconda.atlassian.net/browse/PKG-9838)


### Explanation of changes:

- Fork from conda forge
- remove noarch
- linter fixes


[PKG-9856]: https://anaconda.atlassian.net/browse/PKG-9856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-9838]: https://anaconda.atlassian.net/browse/PKG-9838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ